### PR TITLE
Add global variables for debugging.

### DIFF
--- a/fps - F3 30 fps - F4 120 fps.ahk
+++ b/fps - F3 30 fps - F4 120 fps.ahk
@@ -25,6 +25,7 @@ return
 ; Selects an option from the FPS dropdown at the specified pixel coordinates
 ; relative to a 1440p resolution. These will be scaled for non-1440p resolutions.
 selectFpsOption(x, y) {
+    global settingFpsTookMs
     start := A_TickCount
 
     detectDbdWindowScale()
@@ -35,7 +36,8 @@ selectFpsOption(x, y) {
 
     closeSettings()
 
-    log("Setting FPS took " . (A_TickCount - start) . " ms")
+    settingFpsTookMs := A_TickCount - start
+    log("Setting FPS took " . settingFpsTookMs . " ms")
 }
 
 ; All pixel coordinates are relative to Snoggles 1440p monitor.
@@ -117,14 +119,14 @@ doWithRetriesUntil(actionName, predicateName, maxDurationMs := 500) {
 }
 
 getColor(x, y) {
-    global xScale, yScale
+    global xScale, yScale, lastCheckedColor
     scaledX := Round(x * xScale)
     scaledY := Round(y * yScale)
 
-    PixelGetColor, color, scaledX, scaledY
+    PixelGetColor, lastCheckedColor, scaledX, scaledY
 
-    log("get color at (" . scaledX . ", " . scaledY . ") color=" . color)
-    return color
+    log("get color at (" . scaledX . ", " . scaledY . ") color=" . lastCheckedColor)
+    return lastCheckedColor
 }
 
 ; Click on the scaled coords.


### PR DESCRIPTION
## Summary
Stashes useful debug info in global variables so users can check them without special edits/tools.

![image](https://github.com/user-attachments/assets/f6f780a7-cc23-4688-9fe8-cc5bb918813b)

## Motivation
A user reported that the macro didn't work with his weird tinted reshade settings. Rather than have him download https://learn.microsoft.com/en-us/sysinternals/downloads/debugview and uncomment `OutputDebug`, it'd be useful if he could use AutoHotkey's built-in inspection for (Global) Variables and their contents (Ctrl+V) to see the last color it read before failing.

I also added `settingFpsTookMs` to time the last FPS switch operation.

Global variables considered... helpful?