### PR TITLE
Is whiteish fuzzy

### DIFF
--- a/fps - F3 30 fps - F4 120 fps.ahk
+++ b/fps - F3 30 fps - F4 120 fps.ahk
@@ -213,7 +213,7 @@ log(msg) {
 
 info(msg) {
     ; Uncomment while developing:
-    OutputDebug, %msg% ; view with https://learn.microsoft.com/en-us/sysinternals/downloads/debugview
+    ; OutputDebug, %msg% ; view with https://learn.microsoft.com/en-us/sysinternals/downloads/debugview
 }
 
 doNothing() {

--- a/fps - F3 30 fps - F4 120 fps.ahk
+++ b/fps - F3 30 fps - F4 120 fps.ahk
@@ -78,10 +78,10 @@ isSettingsOpen() {
     ; ']' of ESC: (295, 1350)
     matchDetailsE := getColor(1999, 100)
 
-    ; Black background of back button to disquality all bright images
-    backBlack := getColor(200, 1370)
+    ; Red arrow `<` of back button to add further specificity
+    backRed := getColor(133, 1350)
 
-    return isWhiteish(matchDetailsE) && isBlackish(backBlack)
+    return isWhiteish(matchDetailsE) && isRedish(backRed)
 }
 
 selectGraphicsTab() {
@@ -148,8 +148,38 @@ isWhiteish(color) {
     return isBrightish
 }
 
-isBlackish(color) {
-    return (color & 0xF0F0F0) == 0
+isRedish(color) {
+    b := ((color >> 16) & 0xFF) / 255.0
+    g := ((color >> 8) & 0xFF) / 255.0
+    r := (color & 0xFF) / 255.0
+
+    max := r, min := r
+    if (g > max)
+        max := g
+    if (b > max)
+        max := b
+    if (g < min)
+        min := g
+    if (b < min)
+        min := b
+
+    delta := max - min
+
+    if (delta = 0) {
+        return false  ; grayscale (no hue)
+    } else if (max = r) {
+        hue := 60 * Mod(((g - b) / delta), 6)
+    } else if (max = g) {
+        hue := 60 * (((b - r) / delta) + 2)
+    } else {
+        hue := 60 * (((r - g) / delta) + 4)
+    }
+
+    if (hue < 0)
+        hue += 360
+
+    ; Reddish hue range: 0–20 or 340–360
+    return (hue <= 20 || hue >= 340)
 }
 
 getColor(x, y) {
@@ -183,7 +213,7 @@ log(msg) {
 
 info(msg) {
     ; Uncomment while developing:
-    ; OutputDebug, %msg% ; view with https://learn.microsoft.com/en-us/sysinternals/downloads/debugview
+    OutputDebug, %msg% ; view with https://learn.microsoft.com/en-us/sysinternals/downloads/debugview
 }
 
 doNothing() {

--- a/fps - F3 30 fps - F4 120 fps.ahk
+++ b/fps - F3 30 fps - F4 120 fps.ahk
@@ -60,13 +60,13 @@ openGraphicsSettings() {
     ; Sometimes the game lags with black screen when opening menu first time.
     ; Wait for the screen to open.
     ; Note that the [ ESC ] (295, 1350) button looks pure white, but is slightly off white!
-    doWithRetriesUntil(Func("doNothing"), Func("isSettingsOpen"))
+    doWithRetriesUntil("doNothing", "isSettingsOpen")
 
     ; Select "Graphics" tab
-    doWithRetriesUntil(Func("selectGraphicsTab"), Func("isGraphicsTabSelected"))
+    doWithRetriesUntil("selectGraphicsTab", "isGraphicsTabSelected")
 
     ; Open FPS dropdown
-    doWithRetriesUntil(Func("openFpsMenu"), Func("isFpsMenuOpen"))
+    doWithRetriesUntil("openFpsMenu", "isFpsMenuOpen")
 }
 
 closeSettings() {
@@ -103,8 +103,10 @@ isFpsMenuOpen() {
     return isWhiteish(getColor(1771, 1100))
 }
 
-doWithRetriesUntil(action, predicate, maxDurationMs := 500) {
+doWithRetriesUntil(actionName, predicateName, maxDurationMs := 500) {
     startTime := A_TickCount  ; Get the current time (in milliseconds)
+    action := Func(actionName)
+    predicate := Func(predicateName)
 
     while (A_TickCount - startTime < maxDurationMs) {
         action.Call()


### PR DESCRIPTION
## Summary 
- Handle weirder reshade filters.
- Slight speedup by repeating the action less often
- Improve reliability of FPS menu.

## Motivation
A user reports that the macro doesn't work with their weird reshade filters. The white pixels we're looking for get tinted yellow to `0xdedfc9`.

![DeadByDaylight-EGS-Shipping_2025-04-03_00-38-24_818-redacted](https://github.com/user-attachments/assets/59392106-bfb1-4006-9ed3-5655eb4782f2)

## Solution
### Off-whiteish
`isWhiteish()` now has a threshold variable for the RGB components. I've relaxed it bit to `0xD0`, but they will have to set it to `0xC0`.

Dropping it to `0xA0` did produce to false positives. To avoid this, I've added another check on `isSettingsOpen()` to check the red region of the back button. The perf cost of the second check is minor.

![back button with red region](https://github.com/user-attachments/assets/41e9f58b-7dad-4adc-aacf-f105f205ef78)

### Check repetition > Action repetition
While measuring perf, I noticed that the action (Clicking) might be taking a while and slowing down the runtime. To avoid repeating it when the condition isn't met immediately (which it usually isn't), we repeat the condition check several times with a tighter sleep duration. There may also be other benefits to avoiding sending unnecessary input events to DBD.

### FPS menu
![FPS menu](https://github.com/user-attachments/assets/0f117034-84f3-4063-9c93-41f6b9167afa)
While testing, I did catch one time that waiting a static 50 ms for the FPS menu to open was not enough. We now check that the menu is actually open before selecting a value. The text strokes are thin, but two users sent me 1080p-ish screenshots where the relevant pixel was ~`0xFEFEFE`.

## Performance
Median times for continuously pressing:
- F3: 266 ms
- F4: 297 ms