### PR TITLE
Add `skip startup screens.ahk`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Here you can find macros that will help with the repetitive/tedious aspects of f
 - All .ahk files require [Auto Hotkey v1.1](https://www.autohotkey.com/download/ahk-install.exe).
 - You can easily edit each macro to customize them for non-standard configurations using notepad or ChatGPT.
 
+## Skip Startup Screens
+- Auto-clicks through the DBD startup screens.
+- Times DBD startup.
+- DBD must be fullscreen and visible.
+- DBD does *not* need to be focused.
+
 ## Auto Click
 - Auto-clicker for spending bloodpoints.
 - F6 = Toggle ON / F7 = Toggle OFF

--- a/skip startup screens.ahk
+++ b/skip startup screens.ahk
@@ -1,0 +1,43 @@
+﻿#Persistent
+#SingleInstance Force
+SetTitleMatchMode, 1 ; Exact title match
+
+; Skips DBD startup screens until the [ESC] text on main menu is visible.
+
+isDbdRunning := false
+
+SetTimer, CheckIfDbdRunning, 5000
+return
+
+CheckIfDbdRunning:
+IfWinExist, DeadByDaylight
+{
+    if (!isDbdRunning)
+    {
+        OutputDebug, DBD found. Starting check loop.
+        isDbdRunning := true
+        SetTimer, ClickThroughScreens, 500
+        global StartTime := A_TickCount
+    }
+}
+else
+{
+    isDbdRunning := false
+}
+return
+
+ClickThroughScreens:
+{
+    PixelGetColor, color, 238, 1351, RGB
+    if (color = 0xFFFFFF || (A_TickCount - StartTime > 120000)) ; stop after 2 minutes or [ESC] pixel turns white
+    {
+        OutputDebug, Main menu reached. My work here is done.
+        SetTimer, ClickThroughScreens, Off
+        ToolTip
+        return
+    }
+
+    ToolTip, Clicking through startup screens...
+    ControlClick,, DeadByDaylight
+}
+return

--- a/skip startup screens.ahk
+++ b/skip startup screens.ahk
@@ -41,7 +41,7 @@ ClickThroughScreens:
         SetTimer, clearToolTip, 2000
     } else {
         ; Not loaded/keep clicking...
-        statusUpdate("Clicking through startup screens (" . elapsedSeconds() . " sec)...")
+        ; statusUpdate("Clicking through startup screens (" . elapsedSeconds() . " sec)...")
         ControlClick,, DeadByDaylight
     }
 }

--- a/skip startup screens.ahk
+++ b/skip startup screens.ahk
@@ -1,11 +1,15 @@
 ﻿#Persistent
 #SingleInstance Force
-SetTitleMatchMode, 1 ; Exact title match
-
 ; Skips DBD startup screens until the [ESC] text on main menu is visible.
+; DBD must be fullscreen and visible
 
+; Set showToolTip to false if you don't want tooltip status reports.
+global showToolTip := true
+
+SetTitleMatchMode, 1 ; Exact title match
+CoordMode, Pixel, Screen
+global startTime, xScale, yScale, lastCheckedColor
 isDbdRunning := false
-
 SetTimer, CheckIfDbdRunning, 5000
 return
 
@@ -15,29 +19,69 @@ IfWinExist, DeadByDaylight
     if (!isDbdRunning)
     {
         OutputDebug, DBD found. Starting check loop.
+        startTime := A_TickCount
         isDbdRunning := true
         SetTimer, ClickThroughScreens, 500
-        global StartTime := A_TickCount
     }
-}
-else
-{
+} else {
     isDbdRunning := false
 }
 return
 
 ClickThroughScreens:
 {
-    PixelGetColor, color, 238, 1351, RGB
-    if (color = 0xFFFFFF || (A_TickCount - StartTime > 120000)) ; stop after 2 minutes or [ESC] pixel turns white
+    color := getColor(238, 1351) ; [ESC] main menu white pixel
+    if (color = 0xFFFFFF || (A_TickCount - StartTime > 90000))
     {
-        OutputDebug, Main menu reached. My work here is done.
+        ; Finished/Loaded
         SetTimer, ClickThroughScreens, Off
-        ToolTip
-        return
-    }
 
-    ToolTip, Clicking through startup screens...
-    ControlClick,, DeadByDaylight
+        global dbdLoadTimeSeconds := elapsedSeconds() ; set global var for user retrieval later.
+        statusUpdate("DBD started in " . dbdLoadTimeSeconds . " seconds.")
+        SetTimer, clearToolTip, 2000
+    } else {
+        ; Not loaded/keep clicking...
+        statusUpdate("Clicking through startup screens (" . elapsedSeconds() . " sec)...")
+        ControlClick,, DeadByDaylight
+    }
 }
 return
+
+clearToolTip() {
+    if (showToolTip)
+        ToolTip
+}
+
+elapsedSeconds() {
+    elapsedMs := A_TickCount - startTime
+    return Floor(elapsedMs / 1000)
+}
+
+; All pixel coordinates are relative to a 1440p monitor.
+; Detect a scaling factor for other resolutions such as 1080p.
+; This should be tested every time in case the resolution changes.
+; Runtime of this function was measured at 0 ms, so it's effectively free.
+detectDbdWindowScale() {
+    WinGetPos, ignoredX, ignoredY, DbdWidth, DbdHeight, DeadByDaylight
+
+    ; Scaling factor for monitors at resolutions other than 2560x1440
+    xScale := DbdWidth / 2560
+    yScale := DbdHeight / 1440
+}
+
+getColor(x, y) {
+    detectDbdWindowScale()
+    WinGetPos, winX, winY, winWidth, winHeight, DeadByDaylight
+
+    scaledX := Round(x * xScale) + winX
+    scaledY := Round(y * yScale) + winY
+
+    PixelGetColor, lastCheckedColor, scaledX, scaledY
+
+    return lastCheckedColor
+}
+
+statusUpdate(msg) {
+    if (showToolTip)
+        ToolTip % msg
+}


### PR DESCRIPTION
AFAIK, DBD is the only game that gives you skill checks before you even get to the main menu. Like bruh, lemme go get a glass of water while the game loads and have it finished by the time I'm back.