### PR TITLE
Skip Startup Screens - Handle reshade filters.

### DIFF
--- a/skip startup screens.ahk
+++ b/skip startup screens.ahk
@@ -31,7 +31,7 @@ return
 ClickThroughScreens:
 {
     color := getColor(238, 1351) ; [ESC] main menu white pixel
-    if (color = 0xFFFFFF || (A_TickCount - StartTime > 90000))
+    if ((color | 0x030303) = 0xFFFFFF || (A_TickCount - StartTime > 90000))
     {
         ; Finished/Loaded
         SetTimer, ClickThroughScreens, Off

--- a/skip startup screens.ahk
+++ b/skip startup screens.ahk
@@ -8,7 +8,7 @@ global showToolTip := true
 
 SetTitleMatchMode, 1 ; Exact title match
 CoordMode, Pixel, Screen
-global startTime, xScale, yScale, lastCheckedColor
+global startTime, xScale, yScale
 isDbdRunning := false
 SetTimer, CheckIfDbdRunning, 5000
 return
@@ -30,8 +30,19 @@ return
 
 ClickThroughScreens:
 {
-    color := getColor(238, 1351) ; [ESC] main menu white pixel
-    if ((color | 0x030303) = 0xFFFFFF || (A_TickCount - StartTime > 90000))
+    ; Main menu: bottom of 'E' of '[ESC]' Some users have funky reshade filters that make this as dark as 0xbfc4b1
+    escText := getColor(251, 1358)
+    escTextIsWhite := isWhiteish(escText)
+
+    ; Main menu: Middle of the red '<' arrow
+    ; Can be a dark red without reshade filters, so we must look at hue rather than red component intensity
+    backArrow := getColor(137, 1349)
+    backArrowIsRed := isRedish(backArrow)
+
+    isMainMenuLoaded := escTextIsWhite && backArrowIsRed
+    waitedTooLong := A_TickCount - StartTime > 90000
+
+    if (isMainMenuLoaded || waitedTooLong)
     {
         ; Finished/Loaded
         SetTimer, ClickThroughScreens, Off
@@ -84,4 +95,51 @@ getColor(x, y) {
 statusUpdate(msg) {
     if (showToolTip)
         ToolTip % msg
+}
+
+isRedish(color) {
+    b := ((color >> 16) & 0xFF) / 255.0
+    g := ((color >> 8) & 0xFF) / 255.0
+    r := (color & 0xFF) / 255.0
+
+    max := r, min := r
+    if (g > max)
+        max := g
+    if (b > max)
+        max := b
+    if (g < min)
+        min := g
+    if (b < min)
+        min := b
+
+    delta := max - min
+
+    if (delta = 0) {
+        return false  ; grayscale (no hue)
+    } else if (max = r) {
+        hue := 60 * Mod(((g - b) / delta), 6)
+    } else if (max = g) {
+        hue := 60 * (((b - r) / delta) + 2)
+    } else {
+        hue := 60 * (((r - g) / delta) + 4)
+    }
+
+    if (hue < 0)
+        hue += 360
+
+    ; Reddish hue range: 0–20 or 340–360
+    return (hue <= 20 || hue >= 340)
+}
+
+isWhiteish(color) {
+    ; isBrightish handles reshade filters that transform near-pure-white pixels to:
+    ; - non-white, e.g. tint
+    ; - non-stable values that change based on surrounding pixels (fog removal, bloom, etc.)
+    b := (color >> 16) & 0xFF
+    g := (color >> 8) & 0xFF
+    r := color & 0xFF
+    thresh := 0xb0
+    isBrightish := r >= thresh && g >= thresh && b >= thresh
+
+    return isBrightish
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a4248425-07cc-4da9-a377-112e713668c5)

Funky reshade strikes again. Same approach as FPS macro:
- white text is white enough (> `0xb0b0b0`)
- red arrow has red hue