### PR TITLE
Killer Shuffle rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Here you can find macros that will help with the repetitive/tedious aspects of f
 - F6 = Toggle ON / F7 = Toggle OFF
 
 ## Killer Shuffle
-- Killer will repeatedly move forwards and backwards to allow survivors to easily get in chase (Spin blinding, Gen dancing, etc).
-- F8 = Toggle ON / F9 = Toggle OFF
+- Killer will repeatedly move forwards and backwards in place to allow survivors to get into chase (Spin blinding, Gen dancing, etc.).
+- F8 = start dancing
+- WASD = stop dancing
 
 ## FPS Switch
 - Very quickly switches between 30 & 120 FPS.

--- a/killer shuffle - F8 on - F9 off.ahk
+++ b/killer shuffle - F8 on - F9 off.ahk
@@ -10,60 +10,59 @@ global IsEnabled, IsWDown, IsSDown
 #IfWinActive, DeadByDaylight
 ~F8::
     IsEnabled := true
-
     Loop
     {
-        ; Step Forward
-        disableIfUnfocused()
         If (!IsEnabled)
             Break
-        SendInput, % "{w down}"
-        IsWDown := true
-        Sleep, 70  ; Hold the key down
-        If (!IsEnabled)
-            Break
-        IsWDown := false
-        If (!IsEnabled)
-            Break
-        SendInput, % "{w up}"
+
+        holdKey("w", 70, IsWDown)
 
         Sleep, 50
 
-        ; Step Back
-        disableIfUnfocused()
-        If (!IsEnabled)
-            Break
-        SendInput, % "{s down}"
-        IsSDown := true
-        Sleep, 50  ; Hold the key down
-        If (!IsEnabled)
-            Break
-        IsSDown := false
-        SendInput, % "{s up}"
+        holdKey("s", 50, IsSDown)
     }
 Return
+
+holdKey(key, holdTime, ByRef isKeyDown) {
+    ; If DBD loses focus, stop. Don't spam "wswsws" to other windows.
+    WinGetTitle, title, A
+    if (Trim(title) != "DeadByDaylight") {
+        disable()
+        return
+    }
+    If (!IsEnabled)
+        return
+
+    ; Send the key down event
+    SendInput, % "{" key " down}"
+    isKeyDown := true
+    Sleep, holdTime  ; Hold the key down for the specified time
+
+    If (!IsEnabled)
+        return
+    ; Reset key state and send key up event
+    isKeyDown := false
+    SendInput, % "{" key " up}"
+}
 
 ; WASD key down handlers with pass-through
 ; WS need special handling.
 ; For example, we do not want to send W up if the user starts holding W.
 ~w::
-resetS()
 disable()
+resetS()
 return
 ~s::
-resetW()
 disable()
+resetW()
 return
 ~a::
 ~d::
-resetAndDisable()
+disable()
+resetW()
+resetS()
 return
 
-resetAndDisable() {
-   resetW()
-   resetS()
-   disable()
-}
 resetW() {
     if (IsWDown) {
         SendInput, % "{w up}"
@@ -78,10 +77,4 @@ resetS() {
 }
 disable() {
     IsEnabled := false
-}
-
-disableIfUnfocused() {
-    WinGetTitle, title, A
-    if (Trim(title) != "DeadByDaylight")
-        disable()
 }


### PR DESCRIPTION
## Summary
F8 still starts the macro, but the cancel conditions have changed:
- WASD cancels
- Unfocusing DBD cancels
- F9 no longer cancels and may be used for other purposes

## Motivation
Problems with previous approach:
- I couldn't reliably hit the F9 key
- F9 is far away from the WASD keys I want to hit next.
- I'd tab out of the game and spam "wswswswsws" into chat windows.

## Notes
- It took some special care to make sure WASD out of dancing moves immediately and fluidly. 
- We're running some code on each WASD, but process CPU never exceeds 0.1% and is mostly 0%.

Fixes #13