### PR TITLE
Refactor global declarations.

### DIFF
--- a/fps - F3 30 fps - F4 120 fps.ahk
+++ b/fps - F3 30 fps - F4 120 fps.ahk
@@ -5,6 +5,7 @@
 CoordMode, Pixel, Window
 
 SetMouseDelay, -1 ; Make cursor move instantly rather than mimicking user behavior
+global xScale, yScale, lastCheckedColor
 
 ; Set 30 FPS
 F3::
@@ -39,13 +40,11 @@ selectFpsOption(x, y) {
     info("Setting FPS took " . settingFpsTookMs . " ms")
 }
 
-; All pixel coordinates are relative to Snoggles 1440p monitor.
+; All pixel coordinates are relative to a 1440p monitor.
 ; Detect a scaling factor for other resolutions such as 1080p.
 ; This should be tested every time in case the resolution changes.
 ; Runtime of this function was measured at 0 ms, so it's effectively free.
 detectDbdWindowScale() {
-    global xScale, yScale
-
     WinGetPos, ignoredX, ignoredY, DbdWidth, DbdHeight, DeadByDaylight
 
     ; Scaling factor for monitors at resolutions other than 2560x1440
@@ -76,12 +75,12 @@ closeSettings() {
 isSettingsOpen() {
     ; 'E' of MATCH DETAILS (1999, 100)
     ; ']' of ESC: (295, 1350)
-    matchDetailsE := getColor(1999, 100)
+    global colorMatchDetailsE := getColor(1999, 100)
 
     ; Red arrow `<` of back button to add further specificity
-    backRed := getColor(133, 1350)
+    global colorBackRed := getColor(133, 1350)
 
-    return isWhiteish(matchDetailsE) && isRedish(backRed)
+    return isWhiteish(colorMatchDetailsE) && isRedish(colorBackRed)
 }
 
 selectGraphicsTab() {
@@ -90,7 +89,8 @@ selectGraphicsTab() {
 
 isGraphicsTabSelected() {
     ; 'R' of 'GRAPHICS': (950, 100)
-    return isWhiteish(getColor(950, 100))
+    global colorGraphicsR := getColor(950, 100)
+    return isWhiteish(colorGraphicsR)
 }
 
 openFpsMenu() {
@@ -100,7 +100,8 @@ openFpsMenu() {
 
 isFpsMenuOpen() {
     ; Check for the base of the 2 of the 120: (1771, 1100)
-    return isWhiteish(getColor(1771, 1100))
+    global colorFps120 := getColor(1771, 1100)
+    return isWhiteish(colorFps120)
 }
 
 doWithRetriesUntil(actionName, predicateName, maxDurationMs := 500) {
@@ -183,21 +184,18 @@ isRedish(color) {
 }
 
 getColor(x, y) {
-    global xScale, yScale, lastCheckedColor
     scaledX := Round(x * xScale)
     scaledY := Round(y * yScale)
 
-    PixelGetColor, lastCheckedColor, scaledX, scaledY
+    PixelGetColor, color, scaledX, scaledY
 
-    log("get color at (" . scaledX . ", " . scaledY . ") color=" . lastCheckedColor)
-    return lastCheckedColor
+    log("get color at (" . scaledX . ", " . scaledY . ") color=" . color)
+    return color
 }
 
 ; Click on the scaled coords.
 ; Prevent mouse movement from the user which may cause the click to miss
 scaledClick(x, y) {
-    global xScale, yScale
-
     scaledX := Round(x * xScale)
     scaledY := Round(y * yScale)
 

--- a/killer autohook.ahk
+++ b/killer autohook.ahk
@@ -3,6 +3,8 @@
 ; This macro hooks a carried survivor whenever possible,
 ; adding years of life to your keyboard's spacebar.
 
+global xScale, yScale
+
 SetTimer, HookIfPossible, 100
 SetTimer, detectDbdWindowScale, 1000
 detectDbdWindowScale()
@@ -12,24 +14,21 @@ HookIfPossible:
     if (WinActive("DeadByDaylight")) {
         ; Head of the "carried survivor" icon.
         ; Chosen because it is not white in the same spot as the "Blight Rush" icon.
-        headColor := getColor(228, 1253)
+        global colorHead := getColor(228, 1253)
 
         ; White part of the 'A' of the "[SPACE] HANG" prompt.
-        spaceA := getColor(1258, 1254)
+        global colorSpaceA := getColor(1258, 1254)
 
         ; Black background of the "[SPACE] HANG" prompt to disqualify an all white screen.
-        spaceBg := getColor(1280, 1254)
+        global colorSpaceBg := getColor(1280, 1254)
 
-        ; OutputDebug, %headColor% %spaceA% %spaceBg%
-
-        if (headColor = 0xFFFFFF && spaceA = 0xFFFFFF && spaceBg = 0x000000) {
+        if (colorHead = 0xFFFFFF && colorSpaceA = 0xFFFFFF && colorSpaceBg = 0x000000) {
             Send, {Space}
         }
     }
 return
 
 getColor(x, y) {
-    global xScale, yScale
     scaledX := Round(x * xScale)
     scaledY := Round(y * yScale)
 
@@ -43,8 +42,6 @@ getColor(x, y) {
 ; This should be tested periodically in case the resolution changes.
 ; Runtime of this function was measured at 0 ms, so it's effectively free.
 detectDbdWindowScale() {
-    global xScale, yScale
-
     WinGetPos, ignoredX, ignoredY, DbdWidth, DbdHeight, DeadByDaylight
 
     ; Scaling factor for monitors at resolutions other than 2560x1440


### PR DESCRIPTION
I discovered in #8 that you can declare a variable as global at the top rather than in each method. This would be useful for cleaning up the ones that use xScale, yScale in multiple places.

All colors are now read into global variables so that if users have trouble, we can quickly check which pixels aren't matching and why.

Tested each macro manually.

Resolves #10.