### PR TITLE
#NoEnv

### DIFF
--- a/autoclick - F6 on - F7 off.ahk
+++ b/autoclick - F6 on - F7 off.ahk
@@ -1,4 +1,5 @@
 ﻿#SingleInstance Force
+#NoEnv
 #IfWinActive DeadByDaylight
 if (FileExist("icons/autopurchase.ico"))
     Menu, Tray, Icon, icons/autopurchase.ico

--- a/fps - F3 30 fps - F4 120 fps.ahk
+++ b/fps - F3 30 fps - F4 120 fps.ahk
@@ -1,4 +1,5 @@
 ﻿#SingleInstance Force
+#NoEnv
 #Persistent
 #IfWinActive DeadByDaylight
 if (FileExist("icons/fps-120.ico"))

--- a/fps sleep - F3 30 fps - F4 120 fps.ahk
+++ b/fps sleep - F3 30 fps - F4 120 fps.ahk
@@ -1,4 +1,5 @@
 ﻿#SingleInstance Force
+#NoEnv
 #Persistent
 #IfWinActive DeadByDaylight
 

--- a/killer autohook.ahk
+++ b/killer autohook.ahk
@@ -1,4 +1,5 @@
 ﻿#SingleInstance Force
+#NoEnv
 #Persistent
 
 if (FileExist("icons/hook.ico"))

--- a/killer shuffle - F8 on.ahk
+++ b/killer shuffle - F8 on.ahk
@@ -1,4 +1,5 @@
 ﻿#Persistent
+#NoEnv
 #SingleInstance Force
 
 if (FileExist("icons/shuffle.ico"))

--- a/skip startup screens.ahk
+++ b/skip startup screens.ahk
@@ -1,4 +1,5 @@
 ﻿#Persistent
+#NoEnv
 #SingleInstance Force
 ; Skips DBD startup screens until the [ESC] text on main menu is visible.
 ; DBD must be fullscreen and visible


### PR DESCRIPTION
`#NoEnv` prevents it from reading environment variables. Kinda insane that it does that by default.