### PR TITLE
Add manual keybinds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Here you can find macros that will help with the repetitive/tedious aspects of f
 - Press Ctrl+r to show a counter for the number of times you M1.
 - Useful for killers to track the number of self-care hit rotations in Reactive builds.
 - Disappears after 10 seconds of no hits.
+- `Ctrl+` and `Ctrl-` to manually set (if necessary)
+- `Ctrl+R` to reset to 0.
 
 ## Match Timer
 - A simple match timer that resets when the black bars at the top/bottom of the screen fully disappear.
@@ -50,3 +52,4 @@ Here you can find macros that will help with the repetitive/tedious aspects of f
 
 ## Abandon Match
 - Uses the Abandon Match feature as soon as available.
+- If that doesn't work, activate manually with Ctrl+Shift+A.

--- a/abandon match.ahk
+++ b/abandon match.ahk
@@ -22,6 +22,10 @@ detectDbdWindowScale()
 SetTimer, CheckForAbandon, 500
 return
 
+~^+a::
+abandonMatch()
+return
+
 CheckForAbandon:
 if (isEscapeAbandonOptionVisible()) {
     start := A_TickCount

--- a/hit counter - Ctrl+R.ahk
+++ b/hit counter - Ctrl+R.ahk
@@ -28,6 +28,15 @@ Gui, +LastFound  ; Mark this GUI as the "last found" window
 WinSet, TransColor, 0  ; set black as transparent
 return
 
+~^-::
+if (counter > 0)
+    setCounter(counter - 1)
+Return
+
+~^=::
+setCounter(counter + 1)
+Return
+
 ; Show and reset the counter
 ~^r::
     setCounter(0)


### PR DESCRIPTION
When detection doesn't work, manual backups are helpful.