### PR TITLE
Autospend: open bloodweb, interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Here you can find macros that will help with the repetitive/tedious aspects of f
 - Auto-clicker for spending bloodpoints.
 - F6 = Toggle ON / F7 = Toggle OFF
 
+## Autospend
+- F6 to spend BP using the [fast bloodweb tech](https://www.reddit.com/r/deadbydaylight/s/njguTZBODp).
+- Experimental. May not work.
+- Supports 1080p and 1440p resolutions.
+- Run windowed at these resolutions if you need to.
+- Disable filters if they interfere.
+
 ## Killer Shuffle
 - Killer will repeatedly move forwards and backwards in place to allow survivors to get into chase (Spin blinding, Gen dancing, etc.).
 - F2 = start dancing

--- a/autospend - F6.ahk
+++ b/autospend - F6.ahk
@@ -30,17 +30,6 @@ global enabled := false
     SetTimer, CheckPixels, 100
 Return
 
-; Interrupt
-~F7::
-    disable()
-    Sleep, 100
-    scaledClick(201, 143, options := "", force := true) ; character tab to cancel the autospending
-    Sleep, 100
-    scaledClick(201, 459, options := "", force := true) ; bloodweb tab
-    Sleep, 100
-    scaledMouseMove(910, 755, force := true)
-Return
-
 ^+F6::
 JustCheckLevel:
 ; Debug stub to check level-detection without actually spending
@@ -52,6 +41,19 @@ disable() {
     enabled := false
     ToolTip
     SetTimer, CheckPixels, Off
+
+    MouseGetPos, oldX, oldY
+
+    level := getBloodwebLevel()
+    if (level = 10 or level > 11) {
+        ; Interrupt autopurchase
+        Sleep, 100
+        scaledClick(201, 143, options := "", force := true) ; character tab to cancel the autospending
+        Sleep, 100
+        scaledClick(201, 459, options := "", force := true) ; bloodweb tab
+        Sleep, 100
+        MouseMove, oldX, oldY
+    }
 }
 
 scaledMouseMove(x, y, force := false) {

--- a/autospend.ahk
+++ b/autospend.ahk
@@ -19,6 +19,12 @@ global enabled := false
 ; Start spending
 ~F6::
     enabled := true
+    level := getBloodwebLevel()
+    if (level = -1) {
+        scaledClick(201, 459, options := "", force := true) ; bloodweb tab
+        Sleep, 100
+    }
+
     scaledMouseMove(910, 755)
     ToolTip, Autospending... (wiggle mouse to disable)
     SetTimer, CheckPixels, 100


### PR DESCRIPTION
- Opens the bloodweb if it is not already open.
- Interrupts the bloodweb on mouse wiggle.
- Removed F7 binding.